### PR TITLE
HWTS-31: fix broken link in screen guide

### DIFF
--- a/docs/004-screen.md
+++ b/docs/004-screen.md
@@ -2,4 +2,4 @@
 
 1. [How to “setup” screen using a bash script](https://stackoverflow.com/questions/41068502/how-to-setup-screen-using-a-bash-script)
 2. [Create a detached screen, send a command to it](https://stackoverflow.com/questions/36533676/create-a-detached-screen-send-a-command-to-it)
-3. [A few ways to execute commands remotely using SSH](https://zaiste.net/posts/a_few_ways_to_execute_commands_remotely_using_ssh/)
+3. [A few ways to execute commands remotely using SSH](https://zaiste.net/posts/few-ways-to-execute-commands-remotely-ssh/)


### PR DESCRIPTION
Looks like zaiste.net site has been updated to use dashes instead of underscores in URLs. Fix the link.