### PR TITLE
HWTS-34: add missing sudo

### DIFF
--- a/docs/028-setup-git-shell-user.md
+++ b/docs/028-setup-git-shell-user.md
@@ -107,9 +107,9 @@ EOF
 
 
 
-chmod a+x /home/gitreps/git-shell-commands/no-interactive-login
-chmod a+x /home/gitreps/git-shell-commands/help
-chmod a+x /home/gitreps/git-shell-commands/list
+sudo chmod a+x /home/gitreps/git-shell-commands/no-interactive-login
+sudo chmod a+x /home/gitreps/git-shell-commands/help
+sudo chmod a+x /home/gitreps/git-shell-commands/list
 ```
 
 Now the setup of the home directory is done!


### PR DESCRIPTION
In the howto on ssh+git shell workflow, there is a missing sudo in the section of setting up the home directory of the git repos user.