### PR TITLE
HWTS-35: fix user creation step in git+ssh howto

### DIFF
--- a/docs/028-setup-git-shell-user.md
+++ b/docs/028-setup-git-shell-user.md
@@ -7,8 +7,10 @@ We want to create a Linux user with git repositories in his home directories. Ex
 First, create a new user `vrs`, specify a home directory, and set the default shell to `git-shell`:
 
 ```shell
-sudo useradd --create-home --base-dir /home/gitreps --shell /usr/bin/git-shell vrs
+sudo useradd --create-home --home-dir /home/gitreps --shell /usr/bin/git-shell vrs
 ```
+
+**NOTE**: to delete the new user, use `sudo deluser --remove-home --remove-all-files vrs`.
 
 You can see the list of available shells with the command:
 


### PR DESCRIPTION
To create a user using useradd you either specify home-dir or base-dir. Fix this. Also, mention how to remove the created user. For testing purposes.