### PR TITLE
HWTS-54: i3 howto missing install for brightnessctl

### DIFF
--- a/docs/032-i3-wm-minimal-debian-install.md
+++ b/docs/032-i3-wm-minimal-debian-install.md
@@ -12,6 +12,12 @@ sudo aptitude install xorg lxterminal i3-wm suckless-tools
 
 ## screen brightness
 
+For managing hardware brightness levels we will be using the tool `brightnessctl`:
+
+```shell
+sudo aptitude install brightnessctl
+```
+
 List devices with ability to change brightness:
 
 ```shell


### PR DESCRIPTION
In the HOWTO 032-i3-wm-minimal-debian-install.md there is a section on controlling brightness levels with the utility brightnessctl, but the step for installing it is missing. Add it.

Implements [issue/54](https://github.com/valera-rozuvan/howtos/issues/54)