### PR TITLE
HWTS-59: howto-31 fix name of start VM script

### DIFF
--- a/docs/031-creating-a-new-qemu-vm.md
+++ b/docs/031-creating-a-new-qemu-vm.md
@@ -84,7 +84,7 @@ chmod u+x ./install-vm.sh
 
 After the installation, machine will reboot. You can stop the machine booting, and issue a `halt` command.
 
-Now let's create the normal start up script `start.sh`, which will exclude the CDROM mounting our Debian ISO:
+Now let's create the normal start up script `start-vm.sh`, which will exclude the CDROM mounting our Debian ISO:
 
 ```shell
 #!/bin/bash


### PR DESCRIPTION
In the HOWTO [031-creating-a-new-qemu-vm.md](https://github.com/valera-rozuvan/howtos/blob/main/docs/031-creating-a-new-qemu-vm.md) in the section `create a VM`, the script to start the VM after installation should be called `start-vm.sh`.

Implements [issue/59](https://github.com/valera-rozuvan/howtos/issues/59).