### PR TITLE
HWTS-72: makefile to automate hashsums update

### DIFF
--- a/docs/026-recursive-sha256-workflow.md
+++ b/docs/026-recursive-sha256-workflow.md
@@ -1,4 +1,4 @@
-# Recursive sha256 workflow
+# recursive sha256 workflow
 
 Suppose you have a directory full of files and sub-directories. And you want to generate a file containing sha256 hashes for each file inside this directory. I.e. you want to do a recursive discovery of files, and capture their hashes (for the purpose of future checks against corruption).
 
@@ -74,6 +74,106 @@ with output:
 ```text
 ebf4be0467b616ad13cd1707566eb4bc08fec12fc3517fafdff30d98a068a16f  -
 ```
+
+## using make for incremental updates of a hashsum file
+
+In theory (and in practice!), using a build system such as `make`, we can automatically update our `sha256sum.txt` file when any of the source files we are tracking change. Since upon changes, the last modified timestamp is updated, make can easily figure out which hashsums need to be updated.
+
+So if we keep a separate folder (we will use `.sha` in this example) full of individual hashsum files (each one corresponding to a source file we are tracking), make can then update only those whose source file is newer than the hashsum file.
+
+The build result will be the final `sha256sum.txt`, which is just a concatenation of all the individual hashsum files.
+
+Considering our example from the top, we are going to write a `Makefile` to work with the source files in the folder `stuff`:
+
+```Makefile
+.DEFAULT_GOAL := no_default_target
+no_default_target:
+	@echo "Error: No default target defined. Please specify a target: sha, check, clean-all, clean-cache, and clean."
+	@exit 1
+
+SHAS := $(patsubst stuff/%, .sha/stuff/%, $(shell find stuff/ -type f))
+
+sha: .sha/stuff $(SHAS) stuff.sha256sum.txt stuff.sha256sum.txt.sha
+
+.sha/stuff:
+	mkdir -p .sha/stuff
+
+.sha/stuff/%: stuff/%
+	mkdir -p "`dirname $@`"
+	sha256sum $< > $@
+
+stuff.sha256sum.txt: $(SHAS)
+	cat $(SHAS) > stuff.sha256sum.txt
+	sort -k2 -o stuff.sha256sum.txt stuff.sha256sum.txt
+
+stuff.sha256sum.txt.sha: stuff.sha256sum.txt
+	sha256sum "stuff.sha256sum.txt" > "stuff.sha256sum.txt.sha"
+
+.PHONY: check
+check:
+	sha256sum --check --warn --quiet "stuff.sha256sum.txt"
+	sha256sum --check --warn --quiet "stuff.sha256sum.txt.sha"
+
+.PHONY: clean-all
+clean-all: clean-cache clean
+
+.PHONY: clean-cache
+clean-cache:
+	rm -rf .sha/
+
+.PHONY: clean
+clean:
+	rm -rf "stuff.sha256sum.txt"
+	rm -rf "stuff.sha256sum.txt.sha"
+```
+
+Studying the above `Makefile`, I hope the various commands are clear. Run `make sha` to create initial hashsum files. Note that there is also the `stuff.sha256sum.txt.sha` created, with the intent to be able to check the consistency of the `stuff.sha256sum.txt` file. When any files change in the folder `stuff/`, you just run `make sha` again, and the necessary hashsums will be recalculated (and updated in the resulting `stuff.sha256sum.txt` file.
+
+There are two big downsides to this approach. First, the source folder `stuff/` is hard coded. Maybe one can parameterize the `Makefile`, I don't have that much experience with `make` to know for sure.
+
+The other (even bigger) downside is that `make` doesn't accept files (and folders) with spaces (and other special symbols). So you have to make sure that all the sub-folders and files in `stuff/` are named using just alpha-numeric characters and the `-` character.
+
+A simple Bash script to check for illegal characters:
+
+```shell
+#!/bin/bash
+
+find "$PWD/" -name "* *"
+find "$PWD/" -name "*)*"
+find "$PWD/" -name "*(*"
+find "$PWD/" -name "*[*"
+find "$PWD/" -name "*]*"
+find "$PWD/" -name "*}*"
+find "$PWD/" -name "*{*"
+find "$PWD/" -name "*:*"
+find "$PWD/" -name "*;*"
+find "$PWD/" -name "*,*"
+find "$PWD/" -name "*\$*"
+find "$PWD/" -name "*#*"
+find "$PWD/" -name "*\\\*"
+find "$PWD/" -name "*~*"
+find "$PWD/" -name "*\`*"
+find "$PWD/" -name "*\'*"
+find "$PWD/" -name "*\"*"
+find "$PWD/" -name "*\!*"
+find "$PWD/" -name "*|*"
+find "$PWD/" -name "*@*"
+find "$PWD/" -name "*%*"
+find "$PWD/" -name "*^*"
+find "$PWD/" -name "*&*"
+find "$PWD/" -name "*\**"
+find "$PWD/" -name "*=*"
+find "$PWD/" -name "*+*"
+find "$PWD/" -name "*>*"
+find "$PWD/" -name "*<*"
+find "$PWD/" -name "*\?*"
+
+exit 0
+```
+
+## final thoughts
+
+After several iterations of trying different approaches for automation, I decided to go with a small Bash script which satisfies my needs almost 100%. You can find it at [valera-rozuvan/bash-scripts/utils/update-sha256-hashes.sh](https://github.com/valera-rozuvan/bash-scripts/blob/main/utils/update-sha256-hashes.sh).
 
 Remember to backup your data regularly. Enjoy ;)
 


### PR DESCRIPTION
Discussing a potential strategy for using make to automate the updating of a hashsum file. This is for the HOWTO [Recursive sha256 workflow](https://github.com/valera-rozuvan/howtos/blob/main/docs/026-recursive-sha256-workflow.md). Discuss drawbacks for this approach.

Also mention a Bash script I am currently using which works for me for this purpose.

Implements [issue/72](https://github.com/valera-rozuvan/howtos/issues/72).